### PR TITLE
Fix remove index

### DIFF
--- a/include/templated_tiered.h
+++ b/include/templated_tiered.h
@@ -838,7 +838,7 @@ namespace Seq
             if (idx >= size/2) {
                 size--;
                 T garbage = {};
-                helper<T, Layer>::pop_push(garbage, root, size, size - idx, false, info);
+                helper<T, Layer>::pop_push(garbage, root, size, size - idx + 1, false, info);
             } else {
                 T garbage = {};
                 helper<T, Layer>::pop_push(garbage, root, 0, idx + 1, true, info);


### PR DESCRIPTION
This PR fixes the bug reported in https://github.com/mettienne/tiered-vector/issues/4 where `remove` deletes the wrong index when called with `i` ≥ `size/2`.